### PR TITLE
fix: add typescript to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "h5p-types": "github:boyum/h5p-types",
         "prettier": "^2.6.2",
         "prettier-config": "github:boyum/prettier-config",
+        "typescript": "^4.7.4",
         "vite": "^2.8.6"
       }
     },
@@ -574,6 +575,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/vite": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.1.tgz",
@@ -915,6 +929,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "vite": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "h5p-types": "github:boyum/h5p-types",
     "prettier": "^2.6.2",
     "prettier-config": "github:boyum/prettier-config",
+    "typescript": "^4.7.4",    
     "vite": "^2.8.6"
   },
   "dependencies": {


### PR DESCRIPTION
Currently, the "typescript" module is not part of the development dependencies, so building with `tsc` fails unless one has typescript installed globally (should not be assumed IMHO).

When merged in, the "typescript" modules will be part of the build chain's development dependencies.