### PR TITLE
fix: add .h5pignore

### DIFF
--- a/.h5pignore
+++ b/.h5pignore
@@ -1,0 +1,10 @@
+node_modules
+src
+.github
+.gitignore
+.h5pignore
+package.json
+package-lock.json
+README.md
+vite.config.ts
+tsconfig.json


### PR DESCRIPTION
Currently there's not .h5pignore file telling the H5P-CLI tool what files to not pack into the H5P library file.

When merged in, that file will be added to the repository.